### PR TITLE
Retain the sort order (as published by Phillips)

### DIFF
--- a/fast_kmeans/sort_kmeans.cpp
+++ b/fast_kmeans/sort_kmeans.cpp
@@ -32,14 +32,15 @@ int SortKmeans::runThread(int threadId, int maxIterations) {
         synchronizeAllThreads();
 
         for (int i = startNdx; i < endNdx; ++i) {
-            unsigned short closest = assignment[i];
+            unsigned short initial = assignment[i];
+            unsigned short closest = initial;
             
-            double minDistance = pointCenterDist2(i, closest);
+            double minDistance = pointCenterDist2(i, initial);
 
             for (int o = 1; o < k; ++o) {
-                if (minDistance < sortedCenters[closest * k + o].first) break;
+                if (minDistance < sortedCenters[initial * k + o].first) break;
 
-                const unsigned short j = sortedCenters[closest * k + o].second;
+                const unsigned short j = sortedCenters[initial * k + o].second;
             
                 const double distance = pointCenterDist2(i, j);
                 if (distance < minDistance) {


### PR DESCRIPTION
Without this change, a point may miss comparison to its closest mean in one iteration IMHO.
Phillips fixes "c", and keeps the sort order based on the initial mean "c".
Assuming that a point is assigned to mean 1, and the sort yields closest means [1,2,3,4,5]
Mean 3 is closer, and has the priority [3,5,1,2,4] then after switching to the new sort order, mean 5 will not be considered at all in this iteration, and mean 2 will be considered twice.